### PR TITLE
Fix test imports for Cosd package

### DIFF
--- a/cosd/test_cosd.py
+++ b/cosd/test_cosd.py
@@ -7,12 +7,12 @@ import unittest
 import numpy as np
 from datetime import datetime, timedelta
 
-from cost_vector_math import (
+from cosd.cost_vector_math import (
     CoSDVector, VectorOperations, calculate_drift_velocity,
     calculate_resonance_coupling, cluster_vectors
 )
-from drift_analyzer import CoSDAnalyzer, DriftAnalysisResult
-from semantic_marker_interface import SemanticCluster, MarkerVectorizer
+from cosd.drift_analyzer import CoSDAnalyzer, DriftAnalysisResult
+from cosd.semantic_marker_interface import SemanticCluster, MarkerVectorizer
 
 
 class TestCoSDVectorMath(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fix import paths in cosd test suite so modules load as package

## Testing
- `pytest --import-mode=importlib cosd/test_cosd.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6863dfa844bc83229ecfff30622f1683